### PR TITLE
ajout : entreprise libérée 22juinPau 6juilletToulouse

### DIFF
--- a/agenda.md
+++ b/agenda.md
@@ -8,7 +8,8 @@ description: L'agenda des WalkingDev.
 ## À venir
 | Date       | Lieux           | Sujet                  | Animateurs                     |
 | ---------- | --------------  | ---------------------- | ----------------------------   |
-
+| Juillet, 6.| *Toulouse*      | . **[Entreprise libérée](http://walkingdev.fr/#walkingdev/entreprise-liberee/blob/master/v64/faq.md)**            | . S. Serrot - D. Benoist - C. Aubry   |
+| Juin, 22.  | *Pau*           | . **[Entreprise libérée](http://walkingdev.fr/#walkingdev/entreprise-liberee/blob/master/v64/faq.md)**            | . S. Serrot - D. Benoist  |
 
 
 ## Échus


### PR DESCRIPTION
Ajout des dates pour le walkingdev sur l'entreprise libérée pour Pau et Toulouse.
Denis